### PR TITLE
Fixing how timezone conversion operations get translated to a Snowflake Query

### DIFF
--- a/django_snowflake/__version__.py
+++ b/django_snowflake/__version__.py
@@ -1,0 +1,3 @@
+import pkg_resources
+
+__version__ = pkg_resources.get_distribution('django-snowflake').version

--- a/django_snowflake/base.py
+++ b/django_snowflake/base.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db import DatabaseError as WrappedDatabaseError, connections
 from django.db.backends.base.base import BaseDatabaseWrapper
-from django.utils.asyncio import async_unsafe
 
 import snowflake.connector as Database
 
@@ -117,7 +116,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
         return conn_params
 
-    @async_unsafe
     def get_new_connection(self, conn_params):
         connection = Database.connect(**conn_params)
         return connection
@@ -125,7 +123,6 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def init_connection_state(self):
         pass
 
-    @async_unsafe
     def create_cursor(self, name=None):
         cursor = self.connection.cursor()
         return cursor

--- a/django_snowflake/operations.py
+++ b/django_snowflake/operations.py
@@ -8,7 +8,7 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def _convert_field_to_tz(self, field_name, tzname):
         if settings.USE_TZ:
-            field_name = "CONVERT_TIMEZONE('%s', 'UTC', %s)" % (tzname, field_name)
+            field_name = "CONVERT_TIMEZONE('UTC', '%s', %s)" % (tzname, field_name)
         return field_name
 
     def datetime_extract_sql(self, lookup_type, field_name, tzname):

--- a/django_snowflake/operations.py
+++ b/django_snowflake/operations.py
@@ -1,6 +1,19 @@
+from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
 
-class DatabaseOperations(BaseDatabaseOperations):
 
+class DatabaseOperations(BaseDatabaseOperations):
     def quote_name(self, name):
         return '"%s"' % name.replace('.', '"."')
+
+    def _convert_field_to_tz(self, field_name, tzname):
+        if settings.USE_TZ:
+            field_name = "CONVERT_TIMEZONE('%s', 'UTC', %s)" % (tzname, field_name)
+        return field_name
+
+    def datetime_extract_sql(self, lookup_type, field_name, tzname):
+        field_name = self._convert_field_to_tz(field_name, tzname)
+        return self.date_extract_sql(lookup_type, field_name)
+
+    def date_extract_sql(self, lookup_type, field_name):
+        return "EXTRACT(%s FROM %s)" % (lookup_type.upper(), field_name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-snowflake
-version = 1.0.1
+version = 1.0.2
 author = Manan
 author_email = thakkar1016@gmail.com
 description = A backend for Django and Snowflake

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[metadata]
+name = "django-snowflake"
+version = 1.0.0
+author = Manan
+author_email = thakkar1016@gmail.com
+description = A backend for Django and Snowflake
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/AdmitHub/django-snowflake
+classifiers = 
+    Programming Language :: Python :: 3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = "django-snowflake"
+name = django-snowflake
 version = 1.0.0
 author = Manan
 author_email = thakkar1016@gmail.com

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = django-snowflake
-version = 1.0.0
+version = 1.0.1
 author = Manan
 author_email = thakkar1016@gmail.com
 description = A backend for Django and Snowflake

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='django-snowflake',
 
-    version='1.0.1',
+    version='1.0.2',
 
     description='A backend for Django and Snowflake',
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='django-snowflake',
 
-    version='1.0.0',
+    version='1.0.1',
 
     description='A backend for Django and Snowflake',
 


### PR DESCRIPTION
Our `_convert_field_to_tz` method was passing parameters into SQL based on the parameters expected in MySql's `CONVERT_TZ` function definition, and not the parameters expected by Snowflake's `CONVERT_TIMESTAMP` function definition. 

Essentially, we had the source and target timezone parameters in the wrong order. This PR is to fix that, such that it matches [this expectation from Snowflake](https://docs.snowflake.com/en/sql-reference/functions/convert_timezone.html):

```
CONVERT_TIMEZONE( <source_tz> , <target_tz> , <source_timestamp_ntz> )
```
